### PR TITLE
Send hostname all the way through the request as the Host header

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -151,7 +151,6 @@ func main() {
 			Url:        url,
 			Body:       *flagD,
 			Header:     header,
-			Host:       serverName,
 			Username:   username,
 			Password:   password,
 			ServerName: serverName,

--- a/commands/boom.go
+++ b/commands/boom.go
@@ -33,7 +33,6 @@ type ReqOpts struct {
 	Method   string
 	Url      string
 	Header   http.Header
-	Host     string
 	Body     string
 	Username string
 	Password string
@@ -48,7 +47,7 @@ func (r *ReqOpts) Request() *http.Request {
 	req.Header = r.Header
 
 	// update the Host value in the Request - this is used as the host header in any subsequent request
-	req.Host = r.Host
+	req.Host = r.ServerName
 
 	if r.Username != "" && r.Password != "" {
 		req.SetBasicAuth(r.Username, r.Password)


### PR DESCRIPTION
To make boom behave a little more obviously, i've set the Host header on the request at the earliest possible moment. 

Tests still run ok.

Discussion welcome :)
