### PR TITLE
Ability to use boom as a library and collect the report information

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -170,6 +170,8 @@ func main() {
 		}
 	}
 
+	printer := getPrinter(*output)
+
 	(&boomer.Boomer{
 		Req: &boomer.ReqOpts{
 			Method:       method,
@@ -188,7 +190,7 @@ func main() {
 		DisableCompression: *disableCompression,
 		DisableKeepAlives:  *disableKeepAlives,
 		ProxyAddr:          proxyURL,
-		Output:             *output,
+		Printer:            printer,
 	}).Run()
 }
 
@@ -253,4 +255,18 @@ func parseInputWithRegexp(input, regx string) (matches []string, err error) {
 		err = errors.New("Could not parse provided input")
 	}
 	return
+}
+
+func getPrinter(output string) boomer.Printer {
+	var printer boomer.Printer
+	if output == "csv" {
+		printer = boomer.CSVPrinter{
+			Writer: os.Stdout,
+		}
+	} else {
+		printer = boomer.DetailedPrinter{
+			Writer: os.Stdout,
+		}
+	}
+	return printer
 }

--- a/boomer/boomer.go
+++ b/boomer/boomer.go
@@ -86,7 +86,11 @@ type Boomer struct {
 
 	// Output represents the output type. If "csv" is provided, the
 	// output will be dumped as a csv stream.
+	// DEPRECATED. Use Printer attribute instead.
 	Output string
+
+	// Printer is the implementation of Printer interface to print the report
+	Printer Printer
 
 	// ProxyAddr is the address of HTTP proxy server in the format on "host:port".
 	// Optional.

--- a/boomer/print.go
+++ b/boomer/print.go
@@ -15,9 +15,8 @@
 package boomer
 
 import (
-	"fmt"
+	"os"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -71,6 +70,11 @@ func (r *report) finalize() {
 		default:
 			r.rps = float64(len(r.lats)) / r.total.Seconds()
 			r.average = r.avgTotal / float64(len(r.lats))
+			sort.Float64s(r.lats)
+			if len(r.lats) > 0 {
+				r.fastest = r.lats[0]
+				r.slowest = r.lats[len(r.lats)-1]
+			}
 			r.print()
 			return
 		}
@@ -78,106 +82,17 @@ func (r *report) finalize() {
 }
 
 func (r *report) print() {
-	sort.Float64s(r.lats)
+	var printer Printer
 
 	if r.output == "csv" {
-		r.printCSV()
-		return
-	}
-
-	if len(r.lats) > 0 {
-		r.fastest = r.lats[0]
-		r.slowest = r.lats[len(r.lats)-1]
-		fmt.Printf("\nSummary:\n")
-		fmt.Printf("  Total:\t%4.4f secs.\n", r.total.Seconds())
-		fmt.Printf("  Slowest:\t%4.4f secs.\n", r.slowest)
-		fmt.Printf("  Fastest:\t%4.4f secs.\n", r.fastest)
-		fmt.Printf("  Average:\t%4.4f secs.\n", r.average)
-		fmt.Printf("  Requests/sec:\t%4.4f\n", r.rps)
-		if r.sizeTotal > 0 {
-			fmt.Printf("  Total Data Received:\t%d bytes.\n", r.sizeTotal)
-			fmt.Printf("  Response Size per Request:\t%d bytes.\n", r.sizeTotal/int64(len(r.lats)))
+		printer = CSVPrinter{
+			Writer: os.Stdout,
 		}
-		r.printStatusCodes()
-		r.printHistogram()
-		r.printLatencies()
-	}
-
-	if len(r.errorDist) > 0 {
-		r.printErrors()
-	}
-}
-
-func (r *report) printCSV() {
-	for i, val := range r.lats {
-		fmt.Printf("%v,%4.4f\n", i+1, val)
-	}
-}
-
-// Prints percentile latencies.
-func (r *report) printLatencies() {
-	pctls := []int{10, 25, 50, 75, 90, 95, 99}
-	data := make([]float64, len(pctls))
-	j := 0
-	for i := 0; i < len(r.lats) && j < len(pctls); i++ {
-		current := i * 100 / len(r.lats)
-		if current >= pctls[j] {
-			data[j] = r.lats[i]
-			j++
+	} else {
+		printer = DetailedPrinter{
+			Writer: os.Stdout,
 		}
 	}
-	fmt.Printf("\nLatency distribution:\n")
-	for i := 0; i < len(pctls); i++ {
-		if data[i] > 0 {
-			fmt.Printf("  %v%% in %4.4f secs.\n", pctls[i], data[i])
-		}
-	}
-}
 
-func (r *report) printHistogram() {
-	bc := 10
-	buckets := make([]float64, bc+1)
-	counts := make([]int, bc+1)
-	bs := (r.slowest - r.fastest) / float64(bc)
-	for i := 0; i < bc; i++ {
-		buckets[i] = r.fastest + bs*float64(i)
-	}
-	buckets[bc] = r.slowest
-	var bi int
-	var max int
-	for i := 0; i < len(r.lats); {
-		if r.lats[i] <= buckets[bi] {
-			i++
-			counts[bi]++
-			if max < counts[bi] {
-				max = counts[bi]
-			}
-		} else if bi < len(buckets)-1 {
-			bi++
-		}
-	}
-	fmt.Printf("\nResponse time histogram:\n")
-	for i := 0; i < len(buckets); i++ {
-		// Normalize bar lengths.
-		var barLen int
-		if max > 0 {
-			barLen = counts[i] * 40 / max
-		}
-		fmt.Printf("  %4.3f [%v]\t|%v\n", buckets[i], counts[i], strings.Repeat(barChar, barLen))
-	}
-}
-
-// Prints status code distribution.
-func (r *report) printStatusCodes() {
-	fmt.Printf("\nStatus code distribution:\n")
-	for code, num := range r.statusCodeDist {
-		fmt.Printf("  [%d]\t%d responses\n", code, num)
-	}
-}
-
-func (r *report) printErrors() {
-	fmt.Printf("\nError distribution:\n")
-	for err, num := range r.errorDist {
-		fmt.Printf("  [%d]\t%s\n", num, err)
-	}
+	printer.Print(*r)
 }

--- a/boomer/printer.go
+++ b/boomer/printer.go
@@ -139,3 +139,20 @@ func (d DetailedPrinter) printLatencies() {
 		}
 	}
 }
+
+// ExportPrinter is an implementation of Printer to get Report information after
+// the benchmark is completed. 
+type ExportPrinter struct {
+	Report Report
+}
+
+// Print receives a report and assigns it to exported variable
+func (c *ExportPrinter) Print(r Report) error {
+	c.Report = r
+	return nil
+}
+
+// Returns if it displays the progress bar or not when running the benchmark
+func (c *ExportPrinter) ShouldDisplayProgressBar() bool{
+	return false
+}

--- a/boomer/printer.go
+++ b/boomer/printer.go
@@ -1,0 +1,128 @@
+package boomer
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Printer defines an interface to print a report
+type Printer interface {
+	// Print receives a report and prints it
+	Print(report) error
+}
+
+// CSVPrinter is an implementation of Printer to print the report in csv format
+type CSVPrinter struct {
+	Writer io.Writer
+}
+
+// Print receives a report and prints it
+func (c CSVPrinter) Print(r report) error {
+	for i, val := range r.lats {
+		c.Writer.Write([]byte(fmt.Sprintf("%v,%4.4f\n", i+1, val)))
+	}
+	return nil
+}
+
+// DetailedPrinter is an implementation of Printer to print the details
+// of a report. It prints summary, status codes, histogram, latencies and errors
+type DetailedPrinter struct {
+	Writer io.Writer
+	r      report
+}
+
+// Print receives a report and prints it
+func (d DetailedPrinter) Print(r report) error {
+	d.r = r
+
+	d.printSummary()
+	d.printStatusCodes()
+	d.printHistogram()
+	d.printLatencies()
+
+	if len(d.r.errorDist) > 0 {
+		d.printErrors()
+	}
+	return nil
+}
+
+func (d DetailedPrinter) printSummary() {
+	fmt.Fprintf(d.Writer, "\nSummary:\n")
+	fmt.Fprintf(d.Writer, "  Total:\t%4.4f secs.\n", d.r.total.Seconds())
+	fmt.Fprintf(d.Writer, "  Slowest:\t%4.4f secs.\n", d.r.slowest)
+	fmt.Fprintf(d.Writer, "  Fastest:\t%4.4f secs.\n", d.r.fastest)
+	fmt.Fprintf(d.Writer, "  Average:\t%4.4f secs.\n", d.r.average)
+	fmt.Fprintf(d.Writer, "  Requests/sec:\t%4.4f\n", d.r.rps)
+	if d.r.sizeTotal > 0 {
+		fmt.Fprintf(d.Writer, "  Total Data Received:\t%d bytes.\n", d.r.sizeTotal)
+		fmt.Fprintf(d.Writer, "  Response Size per Request:\t%d bytes.\n", d.r.sizeTotal/int64(len(d.r.lats)))
+	}
+}
+
+func (d DetailedPrinter) printStatusCodes() {
+	fmt.Fprintf(d.Writer, "\nStatus code distribution:\n")
+	for code, num := range d.r.statusCodeDist {
+		fmt.Fprintf(d.Writer, "  [%d]\t%d responses\n", code, num)
+	}
+}
+
+func (d DetailedPrinter) printHistogram() {
+	bc := 10
+	buckets := make([]float64, bc+1)
+	counts := make([]int, bc+1)
+	bs := (d.r.slowest - d.r.fastest) / float64(bc)
+	for i := 0; i < bc; i++ {
+		buckets[i] = d.r.fastest + bs*float64(i)
+	}
+	buckets[bc] = d.r.slowest
+	var bi int
+	var max int
+	for i := 0; i < len(d.r.lats); {
+		if d.r.lats[i] <= buckets[bi] {
+			i++
+			counts[bi]++
+			if max < counts[bi] {
+				max = counts[bi]
+			}
+		} else if bi < len(buckets)-1 {
+			bi++
+		}
+	}
+	fmt.Fprintf(d.Writer, "\nResponse time histogram:\n")
+	for i := 0; i < len(buckets); i++ {
+		// Normalize bar lengths.
+		var barLen int
+		if max > 0 {
+			barLen = counts[i] * 40 / max
+		}
+		fmt.Fprintf(d.Writer, "  %4.3f [%v]\t|%v\n", buckets[i], counts[i], strings.Repeat(barChar, barLen))
+	}
+}
+
+func (d DetailedPrinter) printErrors() {
+	fmt.Fprintf(d.Writer, "\nError distribution:\n")
+	for err, num := range d.r.errorDist {
+		fmt.Fprintf(d.Writer, "  [%d]\t%s\n", num, err)
+	}
+}
+
+// Prints percentile latencies.
+func (d DetailedPrinter) printLatencies() {
+	pctls := []int{10, 25, 50, 75, 90, 95, 99}
+	data := make([]float64, len(pctls))
+	j := 0
+	for i := 0; i < len(d.r.lats) && j < len(pctls); i++ {
+		current := i * 100 / len(d.r.lats)
+		if current >= pctls[j] {
+			data[j] = d.r.lats[i]
+			j++
+		}
+	}
+	fmt.Fprintf(d.Writer, "\nLatency distribution:\n")
+	for i := 0; i < len(pctls); i++ {
+		if data[i] > 0 {
+			fmt.Fprintf(d.Writer, "  %v%% in %4.4f secs.\n", pctls[i], data[i])
+		}
+	}
+}

--- a/boomer/run.go
+++ b/boomer/run.go
@@ -21,6 +21,7 @@ import (
 
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -28,17 +29,18 @@ import (
 // all work is done.
 func (b *Boomer) Run() {
 	b.results = make(chan *result, b.N)
-	if b.Output == "" {
+	printer := b.getPrinter(b.Output)
+	if printer.ShouldDisplayProgressBar() {
 		b.bar = newPb(b.N)
 	}
 
 	start := time.Now()
 	b.run()
-	if b.Output == "" {
+	if printer.ShouldDisplayProgressBar() {
 		b.bar.Finish()
 	}
 
-	printReport(b.N, b.results, b.Output, time.Now().Sub(start))
+	printReport(b.N, b.results, printer, time.Now().Sub(start))
 	close(b.results)
 }
 
@@ -104,4 +106,23 @@ func (b *Boomer) run() {
 	close(jobs)
 
 	wg.Wait()
+}
+
+func (b *Boomer) getPrinter(output string) Printer {
+	if b.Printer != nil {
+		return b.Printer
+	}
+
+	// from this line forward is for backwards compatibility
+	var printer Printer
+	if output == "csv" {
+		printer = CSVPrinter{
+			Writer: os.Stdout,
+		}
+	} else {
+		printer = DetailedPrinter{
+			Writer: os.Stdout,
+		}
+	}
+	return printer
 }


### PR DESCRIPTION
Hi,
This pull request is about adding the ability to use boom as a library on other projects.
For example:
I have a project with a set of urls that I need to benchmark and collect information on every deployment. 
Instead of writing a shell script to output csv and parse all that, It's nice to write Go to use Boom as a library, get the data from the Report struct, do some aggregations and save it to some database.

I abstracted out the process of printing the report with an interface Printer.
Implemented CSVPrinter and DetailedPrinter to keep the same functionality we have today.
Export "report" struct and its fields so that it is accessible outside Boomer.
Deprecated Output field on Boomer in favor of Printer.
Changed boom.go in the root folder to use Printer attr instead of Output.
Created ExportPrinter. An implementation of Printer that allows you to get the Report data out when using boom as a library through boomer.

``` go
        printer := &boomer.ExportPrinter{}

        (&boomer.Boomer{
                Req: &boomer.ReqOpts{
                        Method:       method,
                        URL:          url,
                        Body:         *body,
                        Header:       header,
                        Username:     username,
                        Password:     password,
                        OriginalHost: originalHost,
                },
                N:                  num,
                C:                  conc,
                Qps:                q,
                Timeout:            *t,
                AllowInsecure:      *insecure,
                DisableCompression: *disableCompression,
                DisableKeepAlives:  *disableKeepAlives,
                ProxyAddr:          proxyURL,
                Printer:            printer,
        }).Run()
        fmt.Printf("%#v",printer.Report)
```

Outputs : 

``` go
boomer.Report{AvgTotal:4.155620470000001, Fastest:0.370054046, Slowest:0.529011376, Average:0.41556204700000005, Rps:2.4063218882873914, results:(chan *boomer.result)(0xc20804c160), Total:4155720001, ErrorDist:map[string]int{}, StatusCodeDist:map[int]int{200:10}, Lats:[]float64{0.370054046, 0.382456458, 0.38605293500000004, 0.386620901, 0.39687398100000004, 0.405023067, 0.40805067700000003, 0.418174959, 0.47330207, 0.529011376}, SizeTotal:0, printer:(*boomer.ExportPrinter)(0xc208042200)}
```
