### PR TITLE
[BUGFIX] Read response body to ioutil.Discard to reuse connection.

### DIFF
--- a/boomer/run.go
+++ b/boomer/run.go
@@ -22,6 +22,9 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"io"
+	"io/ioutil"
 )
 
 // Run makes all the requests, prints the summary. It blocks until
@@ -63,8 +66,10 @@ func (b *Boomer) worker(wg *sync.WaitGroup, ch chan *http.Request) {
 		size := int64(0)
 		resp, err := client.Do(req)
 		if err == nil {
-			size = resp.ContentLength
-			code = resp.StatusCode
+			if _, err = io.Copy(ioutil.Discard, resp.Body); err == nil {
+				size = resp.ContentLength
+				code = resp.StatusCode
+			}
 			resp.Body.Close()
 		}
 		if b.bar != nil {

--- a/boomer/run.go
+++ b/boomer/run.go
@@ -66,10 +66,9 @@ func (b *Boomer) worker(wg *sync.WaitGroup, ch chan *http.Request) {
 		size := int64(0)
 		resp, err := client.Do(req)
 		if err == nil {
-			if _, err = io.Copy(ioutil.Discard, resp.Body); err == nil {
-				size = resp.ContentLength
-				code = resp.StatusCode
-			}
+			size = resp.ContentLength
+			code = resp.StatusCode
+			io.Copy(ioutil.Discard, resp.Body)
 			resp.Body.Close()
 		}
 		if b.bar != nil {


### PR DESCRIPTION
Hello. http.Transport don't reuse connection (keep-alive) if response body was not **read** and closed.

This is confusing behaviour. Documentation will be fixed in go 1.5: 
https://github.com/golang/go/issues/5645

Here 2 cap files.
old: https://wix-shareable.s3.amazonaws.com/boom/old.pcap
fixed: https://wix-shareable.s3.amazonaws.com/boom/fixed.pcap

As you can see current version sends FIN,ACK packet after each HTTP response.

Thank you.
