### PR TITLE
Use time.Sleep() instead of time.Tick() when throttling 

### DIFF
--- a/boomer/run.go
+++ b/boomer/run.go
@@ -85,10 +85,11 @@ func (b *Boomer) run() {
 	var wg sync.WaitGroup
 	wg.Add(b.N)
 
-	var throttle <-chan time.Time
+	var throttle time.Duration
 	if b.Qps > 0 {
-		throttle = time.Tick(time.Duration(1e6/(b.Qps)) * time.Microsecond)
+		throttle = time.Duration(1e9/b.Qps) * time.Nanosecond
 	}
+
 	jobs := make(chan *http.Request, b.N)
 	for i := 0; i < b.C; i++ {
 		go func() {
@@ -97,7 +98,7 @@ func (b *Boomer) run() {
 	}
 	for i := 0; i < b.N; i++ {
 		if b.Qps > 0 {
-			<-throttle
+			time.Sleep(throttle)
 		}
 		jobs <- b.Req.Request()
 	}


### PR DESCRIPTION
time.Tick() is not accurate when requests are higher than 10 per second.