### PR TITLE
Add support for custom HTTP host header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
 
   -m  HTTP method, one of GET, POST, PUT, DELETE, HEAD, OPTIONS.
   -h  Custom HTTP headers, name1:value1;name2:value2.
+  -H  Custom HTTP host header.
   -t  Timeout in ms.
   -A  HTTP Accept header.
   -d  HTTP request body.

--- a/boom.go
+++ b/boom.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/rakyll/boom/boomer"
+	"github.com/espebra/boom/boomer"
 )
 
 const (
@@ -40,6 +40,7 @@ var (
 	accept      = flag.String("A", "", "")
 	contentType = flag.String("T", "text/html", "")
 	authHeader  = flag.String("a", "", "")
+	hostHeader  = flag.String("H", "", "")
 
 	output = flag.String("o", "", "")
 
@@ -68,6 +69,7 @@ Options:
 
   -m  HTTP method, one of GET, POST, PUT, DELETE, HEAD, OPTIONS.
   -h  Custom HTTP headers, name1:value1;name2:value2.
+  -H  Custom HTTP host header.
   -t  Timeout in ms.
   -A  HTTP Accept header.
   -d  HTTP request body.
@@ -159,6 +161,7 @@ func main() {
 			URL:      url,
 			Body:     *body,
 			Header:   header,
+			Host:     *hostHeader,
 			Username: username,
 			Password: password,
 		},

--- a/boom.go
+++ b/boom.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/espebra/boom/boomer"
+	"github.com/rakyll/boom/boomer"
 )
 
 const (

--- a/boomer/boomer.go
+++ b/boomer/boomer.go
@@ -35,6 +35,7 @@ type ReqOpts struct {
 	Method   string
 	URL      string
 	Header   http.Header
+	Host     string
 	Body     string
 	Username string
 	Password string
@@ -44,6 +45,9 @@ type ReqOpts struct {
 func (r *ReqOpts) Request() *http.Request {
 	req, _ := http.NewRequest(r.Method, r.URL, strings.NewReader(r.Body))
 	req.Header = r.Header
+	if r.Host != "" {
+		req.Host = r.Host
+	}
 	if r.Username != "" && r.Password != "" {
 		req.SetBasicAuth(r.Username, r.Password)
 	}

--- a/boomer/run_test.go
+++ b/boomer/run_test.go
@@ -76,11 +76,12 @@ func TestQps(t *testing.T) {
 }
 
 func TestRequest(t *testing.T) {
-	var uri, contentType, some, method, auth string
+	var uri, contentType, some, method, auth, host string
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		uri = r.RequestURI
 		method = r.Method
 		contentType = r.Header.Get("Content-type")
+		host = r.Host
 		some = r.Header.Get("X-some")
 		auth = r.Header.Get("Authorization")
 	}
@@ -95,6 +96,7 @@ func TestRequest(t *testing.T) {
 			Method:   "PUT",
 			URL:      server.URL,
 			Header:   header,
+			Host:     "example.com",
 			Username: "username",
 			Password: "password",
 		},
@@ -113,6 +115,9 @@ func TestRequest(t *testing.T) {
 	}
 	if auth != "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" {
 		t.Errorf("Basic authorization is not properly set")
+	}
+	if host != "example.com" {
+		t.Errorf("Host header is not properly set")
 	}
 }
 


### PR DESCRIPTION
Thank you for a nice tool. I need to set a custom host header, so I introduced the -H parameter for this in my fork. Hopefully it will be useful for others.

Please note that the import path github.com/espebra/boom/boomer in boom.go must be changed back to github.com/rakyll/boom/boomer if pulled. Fixes #76.
