### PR TITLE
Fix bug: all connections are not reuse

### DIFF
--- a/boomer/boomer.go
+++ b/boomer/boomer.go
@@ -31,6 +31,10 @@ type result struct {
 	contentLength int64
 }
 
+type RequestBuilder interface {
+	Request() *http.Request
+}
+
 type ReqOpts struct {
 	Method   string
 	URL      string
@@ -53,7 +57,7 @@ func (r *ReqOpts) Request() *http.Request {
 type Boomer struct {
 	// Req represents the options of the request to be made.
 	// TODO(jbd): Make it work with an http.Request instead.
-	Req *ReqOpts
+	Req RequestBuilder
 
 	// N is the total number of requests to make.
 	N int

--- a/boomer/run.go
+++ b/boomer/run.go
@@ -16,6 +16,8 @@ package boomer
 
 import (
 	"crypto/tls"
+	"io"
+	"io/ioutil"
 
 	"sync"
 
@@ -61,6 +63,7 @@ func (b *Boomer) worker(wg *sync.WaitGroup, ch chan *http.Request) {
 		if err == nil {
 			size = resp.ContentLength
 			code = resp.StatusCode
+			io.Copy(ioutil.Discard, resp.Body)
 			resp.Body.Close()
 		}
 		if b.bar != nil {


### PR DESCRIPTION
To ensure http.Client connection reuse, must do two things:
1.Read until Response is complete.
2.Call Body.Close().

you can test it