### PR TITLE
make the second SIGINT exit the program

### DIFF
--- a/boomer/boomer.go
+++ b/boomer/boomer.go
@@ -117,6 +117,7 @@ func (b *Boomer) Run() {
 		<-c
 		// TODO(jbd): Progress bar should not be finalized.
 		newReport(b.N, b.results, b.Output, time.Now().Sub(start)).finalize()
+		signal.Reset(os.Interrupt)
 	}()
 
 	b.runWorkers()


### PR DESCRIPTION
It was not possible to stop boom easily after realising you made a
configuration flag mistake. The only options currently are to manually
go kill it or to type CTRL+\ (SIGQUIT) in the terminal. The former is
annoying and the latter dumps a bunch of unnecessary debug info.

With this change we now unregister the SIGINT handler after it runs the
first (and currently only) time, making subsequent SIGINT signals fall
back to the default of exiting the program.
