### PR TITLE
Error if n < c

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -114,6 +114,10 @@ func main() {
 		usageAndExit("n and c cannot be smaller than 1.")
 	}
 
+	if num < conc {
+		usageAndExit("n cannot be less than c")
+	}
+
 	url := flag.Args()[0]
 	method := strings.ToUpper(*m)
 


### PR DESCRIPTION
Previously if you set n to 50 and concurrency to 100 the program would exit 0
without making any requests. Instead let's print an error message and display
the program's usage.

Happy to add tests but I think this would need a larger refactoring to do flag
parsing outside the main function :( I verified that this works by running it
at the command line with and without n < c.