### PR TITLE
Update README removing -readall and -allow-insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
 
-  -readall              Consumes the entire request body.
-  -allow-insecure       Allow bad/expired TLS/SSL certificates.
   -disable-compression  Disable compression.
   -disable-keepalive    Disable keep-alive, prevents re-use of TCP
                         connections between different HTTP requests.


### PR DESCRIPTION
The flags removed in 7f4c622 and bc64737 were still present in README.md